### PR TITLE
Allow user to specify command-line arguments for PhantomJS

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -136,6 +136,10 @@ A pass-through option specifying javascript to be run after the page object is c
 
 If you need even more control, you may pass in an instance of L<Test::Mojo::Phantom> and it will be used.
 
+=item phantom_args
+
+Specifies an array reference of command-line arguments passed directly to the PhantomJS process.
+
 =back
 
 =head1 DESIGN GOALS

--- a/lib/Mojo/Phantom.pm
+++ b/lib/Mojo/Phantom.pm
@@ -19,6 +19,7 @@ use constant DEBUG => $ENV{MOJO_PHANTOM_DEBUG};
 use constant CAN_CORE_DIE  => !! CORE->can('die');
 use constant CAN_CORE_WARN => !! CORE->can('warn');
 
+has arguments => sub { [] };
 has base    => sub { Mojo::URL->new };
 has bind    => sub { {} };
 has cookies => sub { [] };
@@ -92,7 +93,9 @@ sub execute_file {
   my ($self, $file, $cb) = @_;
   # note that $file might be an object that needs to have a strong reference
 
-  my $proc = Mojo::Phantom::Process->new;
+  my $arguments = $self->arguments // [];
+
+  my $proc = Mojo::Phantom::Process->new(arguments => $arguments);
 
   my $sep = $self->sep;
   my $package = $self->package;
@@ -187,6 +190,10 @@ Please note that this class is not yet as stable as the public api for the test 
 =head1 ATTRIBUTES
 
 L<Mojo::Phantom> inherits the attributes from L<Mojo::Base> and implements the following new ones.
+
+=head2 arguments
+
+An array reference containing command-line arguments to be passed directly to the PhantomJS process.
 
 =head2 base
 

--- a/lib/Mojo/Phantom/Process.pm
+++ b/lib/Mojo/Phantom/Process.pm
@@ -8,6 +8,7 @@ use Mojo::IOLoop;
 use Mojo::IOLoop::Stream;
 
 has [qw/error exit_status pid stream/];
+has arguments => sub { [] };
 
 sub kill {
   my ($self) = @_;
@@ -22,7 +23,7 @@ sub kill {
 sub start {
   my ($self, $file) = @_;
 
-  my $pid = open my $pipe, '-|', 'phantomjs', "$file";
+  my $pid = open my $pipe, '-|', 'phantomjs', @{ $self->arguments }, "$file";
   die 'Could not spawn' unless defined $pid;
   $self->pid($pid);
   $self->emit(spawn => $pid);
@@ -85,6 +86,13 @@ Emitted just after the child process is spawned.
 Passed the new child pid.
 
 =head1 ATTRIBUTES
+
+=head2 arguments
+
+Holds an array reference of arguments passed directly to the PhantomJS executable when it is run.
+
+  my @phantom_args = ('--proxy=127.0.0.1:8080', '--proxy-type='socks5');
+  my $proc = Mojo::Phantom::Process->new(arguments => \@phantom_args);
 
 =head2 error
 

--- a/lib/Test/Mojo/Role/Phantom.pm
+++ b/lib/Test/Mojo/Role/Phantom.pm
@@ -28,11 +28,12 @@ sub phantom_ok {
     );
 
     Mojo::Phantom->new(
-      base    => $base,
-      bind    => \%bind,
-      cookies => $t->ua->cookie_jar->all,
-      setup   => $opts->{setup},
-      package => $opts->{package} || caller,
+      base      => $base,
+      bind      => \%bind,
+      cookies   => $t->ua->cookie_jar->all,
+      setup     => $opts->{setup},
+      package   => $opts->{package} || caller,
+      arguments => $opts->{phantom_args} // [],
     );
   };
 
@@ -196,6 +197,10 @@ A pass-through option specifying javascript to be run after the page object is c
 =item phantom
 
 If you need even more control, you may pass in an instance of L<Test::Mojo::Phantom> and it will be used.
+
+=item phantom_args
+
+Specifies an array reference of command-line arguments passed directly to the PhantomJS process.
 
 =back
 

--- a/t/arguments.t
+++ b/t/arguments.t
@@ -1,0 +1,37 @@
+use Mojolicious::Lite;
+
+any '/' => sub {
+    my $c = shift;
+    $c->cookie( chocolate_chip => "yummy", { expires => time + 60 } );
+    return $c->render( text => 'Cookie has been set.' );
+};
+
+use Test::More;
+use Test::Mojo::WithRoles qw/Phantom/;
+
+use File::Temp ();
+use Mojo::Util qw(slurp);
+
+my $t = Test::Mojo::WithRoles->new;
+
+my $js = <<'JS';
+    perl.ok(phantom.cookiesEnabled, 'cookies are enabled');
+    perl.is(phantom.cookies.length, 1, "cookie has been set");
+JS
+
+my $cookie_file = File::Temp->new();
+my $options = { phantom_args => ["--cookies-file=$cookie_file"], plan => 2 };
+
+$t->phantom_ok('/', $js, $options);
+
+my $cookies = slurp $cookie_file;
+
+like($cookies, qr/chocolate_chip=yummy/, 'cookie found in cookie file');
+
+done_testing;
+
+=head1 DESCRIPTION
+
+Verify that arguments are passed correctly to PhantomJS.
+
+=cut


### PR DESCRIPTION
This pull-request introduces the argument `arguments` for `Mojo::Phantom::Process` and
`Mojo::Phantom`, and `phantom_args` for `Test::Mojo::Role::Phantom`.

Their role is to pass command-line arguments directly to the PhantomJS process.

The motivation behind the pull-request is as follows: 

We've found our PhantomJS tests to sometimes start failing an awful lot. After much debugging, we found out that deleting the contents of the PhantomJS local storage directory solves these problems, so we reckon it sometimes manages to get corrupted, messing up any future tests until it has been reset.

By calling PhantomJS with `--local-storage-path`, we can specify a clean directory to be used for each test, and avoid this problem cleanly.
