### PR TITLE
add option to not automatically call phantom.exit

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,6 +1,8 @@
 requires 'Mojolicious', '6.0'; # cookie_jar->all returns arrayref
 requires 'JavaScript::Value::Escape';
 requires 'Role::Tiny';
+requires 'Test2', '1.302015'; # Test::Builder + Test2 that works together
+requires 'Test2::Suite';
 requires 'Test::More';
 requires 'Test::Mojo::WithRoles';
 

--- a/lib/Mojo/Phantom.pm
+++ b/lib/Mojo/Phantom.pm
@@ -25,6 +25,7 @@ has cookies => sub { [] };
 has package => 'main';
 has 'setup';
 has sep     => '--MOJO_PHANTOM_MSG--';
+has no_exit => 0;
 
 has template => <<'TEMPLATE';
   % my ($self, $url, $js) = @_;
@@ -84,7 +85,9 @@ has template => <<'TEMPLATE';
 
     <%= $js %>;
 
-    phantom.exit();
+    % unless($self->no_exit) {
+      phantom.exit();
+    % }
   });
 TEMPLATE
 
@@ -225,6 +228,11 @@ A string which is used to build a L<Mojo::Template> object.
 It takes as its arguments the instance, a target url, and a string of javascript to be evaluated.
 
 The default handles much of what this module does, you should be very sure of why you need to change this before doing so.
+
+=head2 no_exit
+
+Do not automatically call C<phantom.exit()> after the provided JavaScript code.  This is useful
+when testing asynchronous events.
 
 =head1 METHODS
 

--- a/lib/Test/Mojo/Role/Phantom.pm
+++ b/lib/Test/Mojo/Role/Phantom.pm
@@ -33,6 +33,7 @@ sub phantom_ok {
       cookies => $t->ua->cookie_jar->all,
       setup   => $opts->{setup},
       package => $opts->{package} || caller,
+      no_exit => $opts->{no_exit},
     );
   };
 
@@ -196,6 +197,10 @@ A pass-through option specifying javascript to be run after the page object is c
 =item phantom
 
 If you need even more control, you may pass in an instance of L<Test::Mojo::Phantom> and it will be used.
+
+=item no_exit
+
+Do not automatically call C<phantom.exit()> after the provided JavaScript code.  This is useful when testing asynchronous events.
 
 =back
 

--- a/t/no_exit.t
+++ b/t/no_exit.t
@@ -1,0 +1,91 @@
+use Test2::Bundle::Extended;
+use Mojolicious::Lite;
+
+any '/' => 'main';
+
+use Test::Mojo::WithRoles qw/Phantom/;
+
+my $t = Test::Mojo::WithRoles->new;
+
+my $js = <<'JS';
+  setInterval(function() {
+    perl.ok(1, "async ok");
+    phantom.exit();
+  });
+  perl.ok(1, "normal ok");
+JS
+
+is(
+  intercept { $t->phantom_ok('main', $js, {plan => 2, no_exit => 1}) },
+  array {
+    event Note => sub {
+      call message => 'Subtest: all phantom tests successful';
+    };
+
+    event Subtest => sub {
+      call name => 'all phantom tests successful';
+      call pass => 1;
+
+      call subevents => array {
+        event Plan => sub {
+          call max => 2;
+        };
+
+        event Ok => sub {
+          call name => 'normal ok';
+          call pass => 1;
+        };
+
+        event Ok => sub {
+          call name => 'async ok';
+          call pass => 1;
+        };
+        end();
+      };
+    };
+    end();
+  },
+  'saw both async and non-async oks',
+);
+
+is(
+  intercept { $t->phantom_ok('main', $js, {plan => 1}) },
+  array {
+    event Note => sub {
+      call message => 'Subtest: all phantom tests successful';
+    };
+
+    event Subtest => sub {
+      call name => 'all phantom tests successful';
+      call pass => 1;
+
+      call subevents => array {
+        event Plan => sub {
+          call max => 1;
+        };
+
+        event Ok => sub {
+          call name => 'normal ok';
+          call pass => 1;
+        };
+        end();
+      };
+    };
+    end();
+  },
+  'saw both async and non-async oks',
+);
+
+done_testing;
+
+__DATA__
+
+@@ main.html.ep
+
+<!DOCTYPE html>
+<html>
+  <head></head>
+  <body>
+  </body>
+</html>
+


### PR DESCRIPTION
I found it frequently useful to be able to explicitly call `phantom.exit()` from my own javascript to test asynchronous events, but the explicit call in the template made this hard.
