### PR TITLE
redirect console output to note

### DIFF
--- a/lib/Mojo/Phantom.pm
+++ b/lib/Mojo/Phantom.pm
@@ -26,6 +26,7 @@ has package => 'main';
 has 'setup';
 has sep     => '--MOJO_PHANTOM_MSG--';
 has no_exit => 0;
+has note_console => 1;
 
 has template => <<'TEMPLATE';
   % my ($self, $url, $js) = @_;
@@ -77,20 +78,24 @@ has template => <<'TEMPLATE';
   // Requst page and inject user-provided javascript
   var page = require('webpage').create();
   page.onError = onError;
-  
-  // redirect browser console log to TAP
-  page.onConsoleMessage = function(msg) {
-    perl.note('js console: ' + msg);
-  };
 
-  // redirect console log to TAP
-  (function() {
-    var old = console.log;
-    console.log = function(msg) {
-      perl.note('phantom console: ' + msg);
-      old.apply(this, Array.prototype.slice.call(arguments));
+  % if($self->note_console) {
+  
+    // redirect browser console log to TAP
+    page.onConsoleMessage = function(msg) {
+      perl.note('js console: ' + msg);
     };
-  }());
+
+    // redirect console log to TAP
+    (function() {
+      var old = console.log;
+      console.log = function(msg) {
+        perl.note('phantom console: ' + msg);
+        old.apply(this, Array.prototype.slice.call(arguments));
+      };
+    }());
+  
+  % }
 
   // Additional setup
   <%= $self->setup || '' %>;
@@ -247,6 +252,11 @@ The default handles much of what this module does, you should be very sure of wh
 
 Do not automatically call C<phantom.exit()> after the provided JavaScript code.  This is useful
 when testing asynchronous events.
+
+=head2 note_console
+
+Redirect C<console.log> output to TAP as note events.  This is usually helpful, but can be turned off if it becomes too
+verbose.
 
 =head1 METHODS
 

--- a/lib/Mojo/Phantom.pm
+++ b/lib/Mojo/Phantom.pm
@@ -77,6 +77,11 @@ has template => <<'TEMPLATE';
   // Requst page and inject user-provided javascript
   var page = require('webpage').create();
   page.onError = onError;
+  
+  // redirect browser console log to TAP
+  page.onConsoleMessage = function(msg) {
+    perl.note('js console: ' + msg);
+  };
 
   // Additional setup
   <%= $self->setup || '' %>;

--- a/lib/Mojo/Phantom.pm
+++ b/lib/Mojo/Phantom.pm
@@ -83,6 +83,15 @@ has template => <<'TEMPLATE';
     perl.note('js console: ' + msg);
   };
 
+  // redirect console log to TAP
+  (function() {
+    var old = console.log;
+    console.log = function(msg) {
+      perl.note('phantom console: ' + msg);
+      old.apply(this, Array.prototype.slice.call(arguments));
+    };
+  }());
+
   // Additional setup
   <%= $self->setup || '' %>;
 

--- a/lib/Test/Mojo/Role/Phantom.pm
+++ b/lib/Test/Mojo/Role/Phantom.pm
@@ -35,6 +35,7 @@ sub phantom_ok {
       setup   => $opts->{setup},
       package => $opts->{package} || caller,
       no_exit => $opts->{no_exit},
+      note_console => $opts->{note_console} // 1,
     );
   };
 
@@ -203,6 +204,11 @@ If you need even more control, you may pass in an instance of L<Test::Mojo::Phan
 =item no_exit
 
 Do not automatically call C<phantom.exit()> after the provided JavaScript code.  This is useful when testing asynchronous events.
+
+=item note_console
+
+Redirect C<console.log> output to TAP as note events.  This is usually helpful, but can be turned off if it becomes too
+verbose.
 
 =back
 

--- a/lib/Test/Mojo/Role/Phantom.pm
+++ b/lib/Test/Mojo/Role/Phantom.pm
@@ -23,6 +23,7 @@ sub phantom_ok {
       ok    => 'Test::More::ok',
       is    => 'Test::More::is',
       diag  => 'Test::More::diag',
+      note  => 'Test::More::note',
       fail  => 'Test::More::fail',
       %{ $opts->{bind} || {} },
     );
@@ -179,6 +180,7 @@ The pairs passed are merged into
     ok    => 'Test::More::ok',
     is    => 'Test::More::is',
     diag  => 'Test::More::diag',
+    note  => 'Test::More::note',
     fail  => 'Test::More::fail',
   }
 

--- a/t/console.t
+++ b/t/console.t
@@ -47,6 +47,36 @@ is(
   'console log came through as note message',
 );
 
+is(
+  intercept { $t->phantom_ok('main', $js, {plan => 1, note_console => 0}) },
+  array {
+    event Note => sub {
+      call message => 'Subtest: all phantom tests successful';
+    };
+
+    event Subtest => sub {
+      call name => 'all phantom tests successful';
+      call pass => 1;
+      call effective_pass => 1;
+
+      call subevents => array {
+          event Plan => sub {
+            call max => 1;
+          };
+          event Ok => sub {
+            call name => 'one passing test';
+            call pass => 1;
+            call effective_pass => 1;
+          };
+
+          end();
+      };
+    };
+    end();
+  },
+  'console log came through as note message',
+);
+
 
 $js = <<'JS';
   perl('ok', 1, 'one passing test');
@@ -77,6 +107,35 @@ is(
 
           event Note => sub {
             call message => 'phantom console: this is a console message';
+          };
+          end();
+      };
+    };
+    end();
+  },
+  'console log came through as note message',
+);
+
+is(
+  intercept { $t->phantom_ok('main', $js, {plan => 1, note_console => 0}) },
+  array {
+    event Note => sub {
+      call message => 'Subtest: all phantom tests successful';
+    };
+
+    event Subtest => sub {
+      call name => 'all phantom tests successful';
+      call pass => 1;
+      call effective_pass => 1;
+
+      call subevents => array {
+          event Plan => sub {
+            call max => 1;
+          };
+          event Ok => sub {
+            call name => 'one passing test';
+            call pass => 1;
+            call effective_pass => 1;
           };
           end();
       };

--- a/t/console.t
+++ b/t/console.t
@@ -1,0 +1,62 @@
+use Test2::Bundle::Extended;
+use Mojolicious::Lite;
+
+any '/' => 'main';
+
+use Test::Mojo::WithRoles qw/Phantom/;
+
+my $t = Test::Mojo::WithRoles->new;
+
+my $js = <<'JS';
+  perl('ok', 1, 'one passing test');
+  page.evaluate(function() {
+    console.log('this is a console message');
+  });
+JS
+
+is(
+  intercept { $t->phantom_ok('main', $js, {plan => 1}) },
+  array {
+    event Note => sub {
+      call message => 'Subtest: all phantom tests successful';
+    };
+
+    event Subtest => sub {
+      call name => 'all phantom tests successful';
+      call pass => 1;
+      call effective_pass => 1;
+
+      call subevents => array {
+          event Plan => sub {
+            call max => 1;
+          };
+          event Ok => sub {
+            call name => 'one passing test';
+            call pass => 1;
+            call effective_pass => 1;
+          };
+
+          event Note => sub {
+            call message => 'js console: this is a console message';
+          };
+          end();
+      };
+    };
+    end();
+  },
+  'console log came through as note message',
+);
+
+done_testing;
+
+__DATA__
+
+@@ main.html.ep
+
+<!DOCTYPE html>
+<html>
+  <head></head>
+  <body>
+  </body>
+</html>
+

--- a/t/console.t
+++ b/t/console.t
@@ -47,6 +47,45 @@ is(
   'console log came through as note message',
 );
 
+
+$js = <<'JS';
+  perl('ok', 1, 'one passing test');
+  console.log('this is a console message');
+JS
+
+is(
+  intercept { $t->phantom_ok('main', $js, {plan => 1}) },
+  array {
+    event Note => sub {
+      call message => 'Subtest: all phantom tests successful';
+    };
+
+    event Subtest => sub {
+      call name => 'all phantom tests successful';
+      call pass => 1;
+      call effective_pass => 1;
+
+      call subevents => array {
+          event Plan => sub {
+            call max => 1;
+          };
+          event Ok => sub {
+            call name => 'one passing test';
+            call pass => 1;
+            call effective_pass => 1;
+          };
+
+          event Note => sub {
+            call message => 'phantom console: this is a console message';
+          };
+          end();
+      };
+    };
+    end();
+  },
+  'console log came through as note message',
+);
+
 done_testing;
 
 __DATA__


### PR DESCRIPTION
A log of JavaScript libraries use `console.log()`.  I was missing important diagnostics that would have saved me a lot of frustration had I seen them earlier.  I think others might find this also to be a useful default.

I'd also like to see `note` included by default in addition to `diag` since I personally use it much more frequently.
