### PR TITLE
redirect faux browser console output to note

### DIFF
--- a/lib/Mojo/Phantom.pm
+++ b/lib/Mojo/Phantom.pm
@@ -77,6 +77,11 @@ has template => <<'TEMPLATE';
   // Requst page and inject user-provided javascript
   var page = require('webpage').create();
   page.onError = onError;
+  
+  // redirect browser console log to TAP
+  page.onConsoleMessage = function(msg) {
+    perl.note('js console: ' + msg);
+  };
 
   // Additional setup
   <%= $self->setup || '' %>;

--- a/lib/Test/Mojo/Role/Phantom.pm
+++ b/lib/Test/Mojo/Role/Phantom.pm
@@ -23,6 +23,7 @@ sub phantom_ok {
       ok    => 'Test::More::ok',
       is    => 'Test::More::is',
       diag  => 'Test::More::diag',
+      note  => 'Test::More::note',
       fail  => 'Test::More::fail',
       %{ $opts->{bind} || {} },
     );
@@ -179,6 +180,7 @@ The pairs passed are merged into
     ok    => 'Test::More::ok',
     is    => 'Test::More::is',
     diag  => 'Test::More::diag',
+    note  => 'Test::More::note',
     fail  => 'Test::More::fail',
   }
 

--- a/t/console.t
+++ b/t/console.t
@@ -1,0 +1,62 @@
+use Test2::Bundle::Extended;
+use Mojolicious::Lite;
+
+any '/' => 'main';
+
+use Test::Mojo::WithRoles qw/Phantom/;
+
+my $t = Test::Mojo::WithRoles->new;
+
+my $js = <<'JS';
+  perl('ok', 1, 'one passing test');
+  page.evaluate(function() {
+    console.log('this is a console message');
+  });
+JS
+
+is(
+  intercept { $t->phantom_ok('main', $js, {plan => 1}) },
+  array {
+    event Note => sub {
+      call message => 'Subtest: all phantom tests successful';
+    };
+
+    event Subtest => sub {
+      call name => 'all phantom tests successful';
+      call pass => 1;
+      call effective_pass => 1;
+
+      call subevents => array {
+          event Plan => sub {
+            call max => 1;
+          };
+          event Ok => sub {
+            call name => 'one passing test';
+            call pass => 1;
+            call effective_pass => 1;
+          };
+
+          event Note => sub {
+            call message => 'js console: this is a console message';
+          };
+          end();
+      };
+    };
+    end();
+  },
+  'console log came through as note message',
+);
+
+done_testing;
+
+__DATA__
+
+@@ main.html.ep
+
+<!DOCTYPE html>
+<html>
+  <head></head>
+  <body>
+  </body>
+</html>
+


### PR DESCRIPTION
This is similar to #5 but it redirects only the faux browser console.log.
