### PR TITLE
default to note redirection off in Mojo::Phantom

### DIFF
--- a/lib/Mojo/Phantom.pm
+++ b/lib/Mojo/Phantom.pm
@@ -26,7 +26,7 @@ has package => 'main';
 has 'setup';
 has sep     => '--MOJO_PHANTOM_MSG--';
 has no_exit => 0;
-has note_console => 1;
+has note_console => 0;
 
 has template => <<'TEMPLATE';
   % my ($self, $url, $js) = @_;
@@ -255,8 +255,8 @@ when testing asynchronous events.
 
 =head2 note_console
 
-Redirect C<console.log> output to TAP as note events.  This is usually helpful, but can be turned off if it becomes too
-verbose.
+Redirect C<console.log> output to TAP as note events.  This is usually helpful when writing tests.  The default is
+off for Mojo::Phantom and on for L<Test::Mojo::Role::Phantom>.
 
 =head1 METHODS
 


### PR DESCRIPTION
When using `Mojo::Phantom` sans `Test::Mojo::Role::Phantom`, it is better not to redirect `note` by default, as it is unlikely that perl.note has been setup.
