### PR TITLE
alternate executables

### DIFF
--- a/lib/Mojo/Phantom.pm
+++ b/lib/Mojo/Phantom.pm
@@ -27,6 +27,7 @@ has 'setup';
 has sep     => '--MOJO_PHANTOM_MSG--';
 has no_exit => 0;
 has note_console => 1;
+has 'exe';
 
 has template => <<'TEMPLATE';
   % my ($self, $url, $js) = @_;
@@ -115,6 +116,7 @@ sub execute_file {
   # note that $file might be an object that needs to have a strong reference
 
   my $proc = Mojo::Phantom::Process->new;
+  $proc->exe($self->exe) if $self->exe;
 
   my $sep = $self->sep;
   my $package = $self->package;
@@ -258,6 +260,11 @@ when testing asynchronous events.
 Redirect C<console.log> output to TAP as note events.  This is usually helpful, but can be turned off if it becomes too
 verbose.
 
+=head2 exe
+
+The executable name or path to call PhantomJS.  You may substitute a compatible platform, for example using C<casperjs> to use
+CasperJS.
+
 =head1 METHODS
 
 L<Mojo::Phantom> inherits all methods from L<Mojo::Base> and implements the following new ones.
@@ -277,6 +284,9 @@ Builds the template for PhantomJS to execute and starts it.
 Takes a target url, a string of javascript to be executed in the context that the template provides and a callback.
 By default this is the page context.
 The return value is the same as L</execute_file>.
+
+The executable name or path to call PhantomJS.  You may substitute a compatible platform, for example using C<casperjs> to use
+CasperJS.
 
 =head1 NOTES
 

--- a/lib/Mojo/Phantom/Process.pm
+++ b/lib/Mojo/Phantom/Process.pm
@@ -9,6 +9,8 @@ use Mojo::IOLoop::Stream;
 
 has [qw/error exit_status pid stream/];
 
+has exe => 'phantomjs';
+
 sub kill {
   my ($self) = @_;
   return unless my $pid = $self->pid;
@@ -22,7 +24,7 @@ sub kill {
 sub start {
   my ($self, $file) = @_;
 
-  my $pid = open my $pipe, '-|', 'phantomjs', "$file";
+  my $pid = open my $pipe, '-|', $self->exe, "$file";
   die 'Could not spawn' unless defined $pid;
   $self->pid($pid);
   $self->emit(spawn => $pid);
@@ -104,6 +106,11 @@ The stream's close event will clear this value once the process has ended.
 
 The instance of L<Mojo::IOLoop::Stream> used to monitor the STDOUT of the external process.
 It is created automatically attacted to the L<Mojo::IOLoop/singleton> by running L</start>.
+
+=head2 exe
+
+The executable name or path to call PhantomJS.  You may substitute a compatible platform, for example using C<casperjs> to use
+CasperJS.
 
 =head1 METHODS
 


### PR DESCRIPTION
This allows you to specify an alternate executable for `phantomjs`.  This may help if you have your phantom executable in a funny place, but the main motivation is to be able to use `casperjs`, which seems to have some advantages over vanilla PhantomJS.  CasperJS is essentially a super set of PhantomJS (although there are some tricks for using `require`).  In fact using `casperjs` I was able to run the test suite successfully.

I didn't make any changes to `Test::Mojo::Role::Phantom`, as the template isn't really appropriate for taking advantage of the CasperJS API.  I envision a `Test::Mojo::Role::Casper` could provide an appropriate template and defaults down the line.
