### PR TITLE
Pass the 'exe' option from phantom_ok to Mojo::Phantom

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -5,6 +5,7 @@ requires 'Test2', '1.302015'; # Test::Builder + Test2 that works together
 requires 'Test2::Suite';
 requires 'Test::More';
 requires 'Test::Mojo::WithRoles';
+requires 'Mock::MonkeyPatch';
 
 configure_requires 'IPC::Cmd';
 configure_requires 'Module::Build::Tiny';

--- a/lib/Test/Mojo/Role/Phantom.pm
+++ b/lib/Test/Mojo/Role/Phantom.pm
@@ -37,6 +37,7 @@ sub phantom_ok {
       no_exit => $opts->{no_exit},
       note_console => $opts->{note_console} // 1,
       arguments => $opts->{phantom_args} // [],
+      exe => $opts->{exe},
     );
   };
 
@@ -214,6 +215,13 @@ verbose.
 =item phantom_args
 
 Specifies an array reference of command-line arguments passed directly to the PhantomJS process.
+
+=back
+
+=item exe
+
+The executable name or path to call PhantomJS.  You may substitute a compatible platform, for example using C<casperjs> to use
+CasperJS.
 
 =back
 

--- a/t/arguments.t
+++ b/t/arguments.t
@@ -6,6 +6,7 @@ any '/' => sub {
     return $c->render( text => 'Cookie has been set.' );
 };
 
+use Mock::MonkeyPatch;
 use Test::More;
 use Test::Mojo::WithRoles qw/Phantom/;
 
@@ -27,6 +28,23 @@ $t->phantom_ok('/', $js, $options);
 my $cookies = slurp $cookie_file;
 
 like($cookies, qr/chocolate_chip=yummy/, 'cookie found in cookie file');
+
+do {    # Test passing 'exe' option
+    my $exe;
+    my $mock = Mock::MonkeyPatch->patch(
+        'Mojo::Phantom::Process::start' => sub {
+            my ($self) = @_;
+            $exe = $self->exe;
+            $self->exe('phantomjs');    # Override the value so it can actually run
+            Mock::MonkeyPatch::ORIGINAL(@_);
+        }
+    );
+    $t->phantom_ok('/', 'perl.ok(1, "Test ran with default exe");');
+    is($exe, 'phantomjs', 'exe - default value');
+
+    $t->phantom_ok('/', 'perl.ok(1, "Test ran with custom exe");', { exe => 'myphantom' } );
+    is($exe, 'myphantom', 'exe - custom value');
+};
 
 done_testing;
 


### PR DESCRIPTION
`Mojo::Phantom` has an `exe` option that allows overriding which executable will be used. `phantom_ok` allows passing a hash ref of options. Some of the values in that hash are passed along to `Mojo::Phantom`, but `exe` isn't. This change fixes that.