### PR TITLE
Disable IOLoop timeout

### DIFF
--- a/lib/Mojo/Phantom/Process.pm
+++ b/lib/Mojo/Phantom/Process.pm
@@ -32,7 +32,7 @@ sub start {
   $self->pid($pid);
   $self->emit(spawn => $pid);
 
-  my $stream = Mojo::IOLoop::Stream->new($pipe);
+  my $stream = Mojo::IOLoop::Stream->new($pipe)->timeout(0);
   my $id = Mojo::IOLoop->stream($stream);
   $self->stream($stream);
   $stream->on(error => sub { $self->error($_[1])->kill });

--- a/t/slow.t
+++ b/t/slow.t
@@ -1,0 +1,29 @@
+use Mojolicious::Lite;
+
+any '/' => 'main';
+
+use Test::More;
+use Test::Mojo::WithRoles qw/Phantom/;
+
+my $t = Test::Mojo::WithRoles->new;
+
+my $js = <<'JS';
+  perl('ok', 1, 'ok from phantomjs');
+  setTimeout(function() { perl('ok', 1, 'ok from timeout'); phantom.exit(0); }, 15500 );
+JS
+
+$t->phantom_ok('main', $js, { plan => 2, no_exit => 1 });
+
+done_testing;
+
+__DATA__
+
+@@ main.html.ep
+
+<!DOCTYPE html>
+<html>
+  <head></head>
+  <body>
+  </body>
+</html>
+

--- a/t/slow.t
+++ b/t/slow.t
@@ -12,7 +12,7 @@ my $js = <<'JS';
   setTimeout(function() { perl('ok', 1, 'ok from timeout'); phantom.exit(0); }, 15500 );
 JS
 
-$t->phantom_ok('main', $js, { plan => 2, no_exit => 1 });
+$t->phantom_ok('main', $js, { plan => 2, no_exit => 1, timeout => 20 });
 
 done_testing;
 

--- a/t/timeout.t
+++ b/t/timeout.t
@@ -1,0 +1,81 @@
+use Test2::Bundle::Extended;
+use Mojolicious::Lite;
+
+any '/' => 'main';
+
+use Test::Mojo::WithRoles qw/Phantom/;
+
+my $t = Test::Mojo::WithRoles->new;
+
+my $js = <<'JS';
+  setTimeout(function() { perl('ok', 1, 'ok from timeout'); phantom.exit(0); }, 2000 );
+JS
+
+is(
+  intercept { $t->phantom_ok('main', $js, { plan => 1, no_exit => 1, timeout => 1 }); },
+  array {
+    event Note => sub {
+      call message => 'Subtest: all phantom tests successful';
+    };
+    event Subtest => sub {
+      call name => 'all phantom tests successful';
+      call pass => 0;
+      call effective_pass => 0;
+
+      call subevents => array {
+        event Plan => sub {
+          call max => 1;
+        };
+        event Ok => sub {
+          call name => 'Aborting test due to timeout';
+          call pass => 0;
+          call effective_pass => 0;
+        };
+        event Diag => sub {
+          call message => "  Failed test 'Aborting test due to timeout'\n";
+        };
+        event Diag => sub {
+          call message => match qr/^  at /;
+        };
+        event Diag => sub {
+          call message => "phantom exitted with signal: 9";
+        };
+        event Diag => sub {
+          call message => "Looks like you failed 1 test of 1.\n";
+        };
+        end();
+      };
+    };
+    event Diag => sub {
+      call message => "  Failed test 'all phantom tests successful'\n";
+    };
+    event Diag => sub {
+      call message => match qr/^  at /;
+    };
+    end;
+  },
+  'Test exited because timeout was reached',
+);
+
+$t->phantom_ok('main', $js, { plan => 1, no_exit => 1, timeout => 0, name => "No timeout, test ok" });
+
+$js = <<'JS';
+  perl('ok', 1, 'ok from phantomjs');
+  phantom.exit(0);
+JS
+
+$t->phantom_ok('main', $js, { plan => 1, no_exit => 1, name => "Default timeout, test exits cleanly" });
+
+done_testing;
+
+__DATA__
+
+@@ main.html.ep
+
+<!DOCTYPE html>
+<html>
+  <head></head>
+  <body>
+  </body>
+</html>
+


### PR DESCRIPTION
If the phantomjs process is slow to respond (for whatever reason), the IOLoop's
timeout will close the connection. So any later test-result from phantomjs will
be ignored by the parent process.

This is especially a problem if no plan has been specified when calling
phantom_ok, as a single ok before the timeout will make the subtest pass.

Note that the included test is quite slow, as it needs to run for more than 15 seconds to illustrate the problem on a non-modified Mojo:Phantom::Process.